### PR TITLE
Fix firefox latest version update error

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,3 +17,5 @@ override['mysql']['bind_address'] = '127.0.0.1'
 override['mysql']['allow_remote_root'] = true
 override['mysql']['remove_anonymous_users'] = true
 override['mysql']['remove_test_database'] = true
+
+override['firefox']['version'] = '39.0'


### PR DESCRIPTION
Disable firefox upgrade to latest version ,To avoid authentication failure during upgrade,
